### PR TITLE
Better Field name generation.

### DIFF
--- a/c#/aWhere.Api.CodeSample/aWhere.Api.Business/FieldModel.cs
+++ b/c#/aWhere.Api.CodeSample/aWhere.Api.Business/FieldModel.cs
@@ -47,21 +47,26 @@ namespace aWhere.Api.Business {
 
         public Field BuildRandomField() {
             Menus.PrintEachLetterToConsole("Generating random Field.....");
-            Field defaultField = new Field();
-            defaultField.id = defaultField.GenerateRandomString();
-            defaultField.name = defaultField.id;
-            defaultField.farmId = NEW_FIELD_FARM_ID;
-            defaultField.acres = NEW_FIELD_ACRES;
-            defaultField.centerPoint = new CenterPoint(NEW_FIELD_LATITUDE, NEW_FIELD_LONGITUDE);
-            Menus.PrintEachLetterToConsole(String.Format("Field ID: {0,-20}", defaultField.id));
-            Menus.PrintEachLetterToConsole(String.Format("Field Name: {0,-20}", defaultField.name));
-            Menus.PrintEachLetterToConsole(String.Format("Field Farm ID: {0,-20}", defaultField.farmId));
-            Menus.PrintEachLetterToConsole(String.Format("Field Acres: {0,-20}", defaultField.acres));
-            Menus.PrintEachLetterToConsole(String.Format("Field Latitude: {0,-20}", defaultField.centerPoint.Latitude));
-            Menus.PrintEachLetterToConsole(String.Format("Field Longitude: {0,-20}", defaultField.centerPoint.Longitude));
+            
+            Field demoField = new Field()
+            {
+                id = GenerateRandomFieldName(),
+                farmId = NEW_FIELD_FARM_ID,
+                acres = NEW_FIELD_ACRES,
+                centerPoint = new CenterPoint(NEW_FIELD_LATITUDE, NEW_FIELD_LONGITUDE)
+            };
+
+            demoField.name = demoField.id;
+
+            Menus.PrintEachLetterToConsole(String.Format("Field ID: {0,-20}", demoField.id));
+            Menus.PrintEachLetterToConsole(String.Format("Field Name: {0,-20}", demoField.name));
+            Menus.PrintEachLetterToConsole(String.Format("Field Farm ID: {0,-20}", demoField.farmId));
+            Menus.PrintEachLetterToConsole(String.Format("Field Acres: {0,-20}", demoField.acres));
+            Menus.PrintEachLetterToConsole(String.Format("Field Latitude: {0,-20}", demoField.centerPoint.Latitude));
+            Menus.PrintEachLetterToConsole(String.Format("Field Longitude: {0,-20}", demoField.centerPoint.Longitude));
             Console.WriteLine();
 
-            return defaultField;
+            return demoField;
         }
 
         #endregion Methods

--- a/c#/aWhere.Api.CodeSample/aWhere.Api.Business/Weather.cs
+++ b/c#/aWhere.Api.CodeSample/aWhere.Api.Business/Weather.cs
@@ -16,10 +16,19 @@ namespace aWhere.Api.Business {
 
         #region Methods
 
-        public string GenerateRandomString() {
-            string path = Path.GetRandomFileName();
-            path = path.Replace(".", ""); // Remove the period
-            return path;
+        public string GenerateRandomFieldName() {
+            StringBuilder baseName = new StringBuilder();
+            baseName.Append("DemoField-");
+
+            // Generate random number
+            Random randomNum = new Random(DateTime.Now.Millisecond);
+            string randomNumber = randomNum.Next().ToString();
+
+            // Combine the base name and the random number, then cast to String
+            baseName.Append(randomNumber);
+            string completedName = baseName.ToString();
+
+            return completedName;
         }
 
         #endregion Methods


### PR DESCRIPTION
## Pull Request Details

The old way of generating field names was a bit too cryptic. You would end up with a field name of "xs2352dsgs" which was really annoying to type and not reflective of how a Field would actually be named.

This PR includes code changes which simply generate a much easier to read/type pattern: 
`DemoField-xxxxxxx` 
The placeholder x's represent a random int that is generated.

You'll end up with something much cleaner, like "DemoField-212412".
